### PR TITLE
feat: load config meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "bugs": "https://github.com/forcedotcom/cli",
   "dependencies": {
     "@oclif/config": "^1.17.0",
-    "@salesforce/command": "^3.0.1",
-    "@salesforce/core": "^2.13.0",
+    "@salesforce/command": "^3.0.4",
+    "@salesforce/core": "^2.15.1",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@oclif/config": "^1.17.0",
     "@salesforce/command": "^3.0.4",
-    "@salesforce/core": "^2.15.1",
+    "@salesforce/core": "^2.15.2",
     "tslib": "^1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,11 @@
   "license": "BSD-3-Clause",
   "oclif": {
     "commands": "./lib/commands",
+    "hooks": {
+      "init": [
+        "./lib/hooks/init/load_config_meta"
+      ]
+    },
     "bin": "sfdx",
     "devPlugins": [
       "@oclif/plugin-help"

--- a/src/hooks/init/load_config_meta.ts
+++ b/src/hooks/init/load_config_meta.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { Hook, IPlugin } from '@oclif/config';
+import { tsPath } from '@oclif/config/lib/ts-node';
+import { ConfigPropertyMeta, Logger } from '@salesforce/core';
+import { Config } from '@salesforce/core';
+import { isObject } from '@salesforce/ts-types';
+
+const log = Logger.childFromRoot('plugin-config:load_config_meta');
+const OCLIF_META_PJSON_KEY = 'configMeta';
+
+function loadConfigMeta(plugin: IPlugin): ConfigPropertyMeta | undefined {
+  let configMetaRequireLocation: string | undefined;
+
+  try {
+    const configMetaPath = plugin.pjson?.oclif?.[OCLIF_META_PJSON_KEY];
+
+    if (typeof configMetaPath !== 'string') {
+      return;
+    }
+
+    const relativePath = tsPath(plugin.root, configMetaPath);
+
+    // use relative path if it exists, require string as is
+    configMetaRequireLocation = relativePath ?? configMetaPath;
+  } catch {
+    return;
+  }
+
+  if (!configMetaRequireLocation) {
+    return;
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const configMetaPathModule = require(configMetaRequireLocation);
+    return configMetaPathModule?.default ?? configMetaPathModule;
+  } catch {
+    log.error(`Error trying to load config meta from ${configMetaRequireLocation}`);
+    return;
+  }
+}
+
+const hook: Hook<'init'> = ({ config: oclifConfig }) => {
+  const loadedConfigMetas = (oclifConfig.plugins || [])
+    .map((plugin) => {
+      const configMeta = loadConfigMeta(plugin);
+      if (!configMeta) {
+        log.info(`No config meta found for ${plugin.name}`);
+      }
+
+      return configMeta;
+    })
+    .filter(isObject);
+
+  const flattenedConfigMetas = [].concat(...loadedConfigMetas);
+
+  if (flattenedConfigMetas.length) {
+    Config.addAllowedProperties(flattenedConfigMetas);
+  }
+};
+
+export default hook;

--- a/test/config-meta-mocks/javascript-lib/lib/config-meta.js
+++ b/test/config-meta-mocks/javascript-lib/lib/config-meta.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+
+exports.default = [
+  {
+    key: 'customKey',
+  },
+];

--- a/test/config-meta-mocks/javascript-lib/package.json
+++ b/test/config-meta-mocks/javascript-lib/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sfdx-cli-ts-plugin",
+  "oclif": {
+    "configMeta": "./lib/config-meta"
+  }
+}

--- a/test/config-meta-mocks/typescript-src/package.json
+++ b/test/config-meta-mocks/typescript-src/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sfdx-cli-ts-plugin",
+  "oclif": {
+    "configMeta": "./lib/config-meta"
+  }
+}

--- a/test/config-meta-mocks/typescript-src/src/config-meta.ts
+++ b/test/config-meta-mocks/typescript-src/src/config-meta.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+export default [
+  {
+    key: 'customKey',
+  },
+];

--- a/test/config-meta-mocks/typescript-src/tsconfig.json
+++ b/test/config-meta-mocks/typescript-src/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./lib"
+  }
+}

--- a/test/hooks/load_config_meta.test.ts
+++ b/test/hooks/load_config_meta.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import * as path from 'path';
+import { $$, expect, test } from '@salesforce/command/lib/test';
+import { Config } from '@salesforce/core';
+import { stubMethod } from '@salesforce/ts-sinon';
+import { IPlugin } from '@oclif/config';
+import { SinonStub } from 'sinon';
+import tsSrcConfigMetaMock from '../config-meta-mocks/typescript-src/src/config-meta';
+import jsLibConfigMetaMock from '../config-meta-mocks/javascript-lib/lib/config-meta';
+
+describe('hooks', () => {
+  beforeEach(() => {
+    stubMethod($$.SANDBOX, Config, 'addAllowedProperties');
+  });
+
+  test
+    .stdout()
+    .loadConfig()
+    .do((ctx) => {
+      const mockPluginRoot = path.resolve(__dirname, '../config-meta-mocks/typescript-src');
+      ctx.config.plugins.push(({
+        root: mockPluginRoot,
+        hooks: {},
+        pjson: require(path.resolve(mockPluginRoot, 'package.json')),
+      } as unknown) as IPlugin);
+    })
+    .hook('init')
+    .do(() => {
+      expect(tsSrcConfigMetaMock).to.deep.equal([
+        {
+          key: 'customKey',
+        },
+      ]);
+      expect((Config.addAllowedProperties as SinonStub).firstCall.args[0]).to.deep.equal(tsSrcConfigMetaMock);
+    })
+    .it('loads config metas from a ts src directory');
+
+  test
+    .stdout()
+    .loadConfig()
+    .do((ctx) => {
+      const mockPluginRoot = path.resolve(__dirname, '../config-meta-mocks/javascript-lib');
+      ctx.config.plugins.push(({
+        root: mockPluginRoot,
+        hooks: {},
+        pjson: require(path.resolve(mockPluginRoot, 'package.json')),
+      } as unknown) as IPlugin);
+    })
+    .hook('init')
+    .do(() => {
+      expect(jsLibConfigMetaMock).to.deep.equal([
+        {
+          key: 'customKey',
+        },
+      ]);
+      expect((Config.addAllowedProperties as SinonStub).firstCall.args[0]).to.deep.equal(jsLibConfigMetaMock);
+    })
+    .it('loads config metas from a js lib directory');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@salesforce/dev-config/tsconfig",
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "lib"
   },
   "include": ["./src/**/*.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,10 +493,10 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.15.1.tgz#c5fdd1a95575f4a20cf707e0ad0b80d17ab03c6d"
-  integrity sha512-XDnsXe++9eUYuMIlBl0OcEfElnWdJlx/a43BMpFK9rOy2S7xoUEkPzXm7fjQXBj52mTMG+6FXPYLQEs+hZZ+5w==
+"@salesforce/core@^2.15.2":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.15.2.tgz#7e2b0ac6c1d67f850a461e007298d1381b37c07a"
+  integrity sha512-PCP9HdGEl4us8X66tOfwlTOGFRju8m7ezqfBlH7nRzmKw57i2l0LhXBEZ+DPwEBtAwa9wlvd9FhMmlhUYhm/EQ==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,10 +477,10 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@salesforce/command@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/@salesforce/command/-/command-3.0.1.tgz#b03d3a15ab2758cb3fa0ce9b35f1f784518bc330"
-  integrity sha512-Cgovnj1upVfOo7HYGsJtRJndnA6Lz34+wyLZAh29oOZnLEvUrCQ3FpdbeYjYWjcWHdWM5O31/T05jNoO2328bA==
+"@salesforce/command@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@salesforce/command/-/command-3.0.4.tgz#2ef88c6f5e47f0650800b3c72ca90d4a99ddb0e2"
+  integrity sha512-1tkhoIpnf/Fu+fG2ITBU9wfjGVtnhFkORIlYRgceydRS2P66JkgQ2Tb+kteiA8I+YsqxkBZK1w+5m9VIlTRcrw==
   dependencies:
     "@oclif/command" "^1.5.17"
     "@oclif/errors" "^1.2.2"
@@ -493,17 +493,18 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.13.0":
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.13.0.tgz#217a703d901aeac45ce29aa1c2473d6c24221340"
-  integrity sha512-lPijkej9cBix3QztRDa4YYbGJcLkrc+wNDE+bgOxI9VxTpoNuclOGkaKsqqE6HUItCS7p5iJTcK0gEJ2Xl81lA==
+"@salesforce/core@^2.15.1":
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.15.1.tgz#c5fdd1a95575f4a20cf707e0ad0b80d17ab03c6d"
+  integrity sha512-XDnsXe++9eUYuMIlBl0OcEfElnWdJlx/a43BMpFK9rOy2S7xoUEkPzXm7fjQXBj52mTMG+6FXPYLQEs+hZZ+5w==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
-    "@salesforce/kit" "^1.3.2"
+    "@salesforce/kit" "^1.3.3"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.0.0"
     "@types/graceful-fs" "^4.1.3"
     "@types/jsforce" "1.9.23"
+    "@types/mkdirp" "1.0.0"
     debug "^3.1.0"
     graceful-fs "^4.2.4"
     jsen "0.6.6"
@@ -584,9 +585,9 @@
     "@salesforce/ts-types" "^1.4.2"
     tslib "^1.10.0"
 
-"@salesforce/kit@^1.3.2":
+"@salesforce/kit@^1.3.3":
   version "1.3.3"
-  resolved "https://registry.npmjs.org/@salesforce/kit/-/kit-1.3.3.tgz#eaea23b1be7aebb81f9f091c8f77c2733a8ae710"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.3.3.tgz#eaea23b1be7aebb81f9f091c8f77c2733a8ae710"
   integrity sha512-Ed5lh8xyCwaXeB1Sovr9xbQZ1tpQg5vSeNvKROlJQRk4Gj3IBm73pKPPuNn+AeXN51lWr9my0ftLREtyig3FoA==
   dependencies:
     "@salesforce/ts-types" "^1.4.3"
@@ -751,6 +752,13 @@
   version "1.2.0"
   resolved "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
+
+"@types/mkdirp@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-1.0.0.tgz#16ce0eabe4a9a3afe64557ad0ee6886ec3d32927"
+  integrity sha512-ONFY9//bCEr3DWKON3iDv/Q8LXnhaYYaNDeFSN0AtO5o4sLf9F0pstJKKKjQhXE0kJEeHs8eR6SAsROhhc2Csw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/mocha@^7.0.2":
   version "7.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -493,9 +493,9 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@2.13.0":
+"@salesforce/core@^2.13.0":
   version "2.13.0"
-  resolved "https://registry.npmjs.org/@salesforce/core/-/core-2.13.0.tgz#217a703d901aeac45ce29aa1c2473d6c24221340"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.13.0.tgz#217a703d901aeac45ce29aa1c2473d6c24221340"
   integrity sha512-lPijkej9cBix3QztRDa4YYbGJcLkrc+wNDE+bgOxI9VxTpoNuclOGkaKsqqE6HUItCS7p5iJTcK0gEJ2Xl81lA==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"


### PR DESCRIPTION
### What does this PR do?
Dynamically loads config meta files defined on `Config.plugins` through their package.json on the `oclif.configMeta` key. These `ConfigPropertyMeta` values are added to the definition used on `Config.allowedProperties` enabling plugins to define custom keys for sfdx config `get` and `set` commands.

⚠️ Depends on new API `Config.setAllowedProperties` https://github.com/forcedotcom/sfdx-core/pull/320, after it is merged and released:
- [x] Bump version of `sfdx-core` on this PR
- [ ] Bump version of `@salesforce/command` otherwise it won't be able to load custom keys and will get/set commands will fail (https://github.com/forcedotcom/cli-packages/pull/131)

### What issues does this PR fix or reference?
@W-7187253@