### PR TITLE
fix: remove force: namespace from examples

### DIFF
--- a/messages/set.json
+++ b/messages/set.json
@@ -4,7 +4,7 @@
   "globalLong": "Sets the configuration variables globally, so they can be used from any directory.",
   "globalHelp": "Add the --global flag to set config outside of a project.",
   "examples": [
-    "sfdx force:config:set defaultusername=me@my.org defaultdevhubusername=me@myhub.org",
-    "sfdx force:config:set defaultdevhubusername=me@myhub.org -g"
+    "sfdx config:set defaultusername=me@my.org defaultdevhubusername=me@myhub.org",
+    "sfdx config:set defaultdevhubusername=me@myhub.org -g"
   ]
 }


### PR DESCRIPTION
### What does this PR do?

Remove the "force:" namespace in the examples of the config:set command-line help

### What issues does this PR fix or reference?

n/a