### PR TITLE
feat: use `@salesforce/core@v3` to support sf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,14 +73,12 @@ workflows:
             - release-management/test-package
       - release-management/release-package:
           sign: true
-          github-release: true
-          prerelease: true
           tag: sf
           requires:
             - release-management/test-package
           filters:
             branches:
-              only: main
+              only: v2
           context: CLI_CTC
   test-ts-update:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,8 @@ workflows:
       - release-management/release-package:
           sign: true
           github-release: true
+          prerelease: true
+          tag: sf
           requires:
             - release-management/test-package
           filters:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "shx": "0.3.3",
     "sinon": "^11.1.1",
     "ts-node": "^10.0.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.5"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@oclif/config": "^1.17.0",
     "@salesforce/command": "^3.0.5",
-    "@salesforce/core": "^2.15.2",
+    "@salesforce/core": "^3.3.1",
     "tslib": "^2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-config",
   "description": "configure the Salesforce CLI",
-  "version": "1.2.13",
+  "version": "2.0.0",
   "author": "Salesforce",
   "bugs": "https://github.com/forcedotcom/cli",
   "dependencies": {

--- a/src/commands/config/get.ts
+++ b/src/commands/config/get.ts
@@ -26,7 +26,8 @@ export class Get extends ConfigCommand {
     const argv = this.parseArgs();
 
     if (!argv || argv.length === 0) {
-      throw SfdxError.create('@salesforce/plugin-config', 'get', 'NoConfigKeysFound', []);
+      const errorMessage = messages.getMessage('NoConfigKeysFound');
+      throw new SfdxError(errorMessage, 'NoConfigKeysFound');
     } else {
       const results: ConfigInfo[] = [];
       const aggregator = await ConfigAggregator.create();

--- a/src/commands/config/unset.ts
+++ b/src/commands/config/unset.ts
@@ -30,7 +30,8 @@ export class UnSet extends ConfigCommand {
     const argv = this.parseArgs();
 
     if (!argv || argv.length === 0) {
-      throw SfdxError.create('@salesforce/plugin-config', 'unset', 'NoConfigKeysFound');
+      const errorMessage = messages.getMessage('NoConfigKeysFound');
+      throw new SfdxError(errorMessage, 'NoConfigKeysFound');
     } else {
       const config: Config = await Config.create(Config.getDefaultOptions(this.flags.global));
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,7 @@ export abstract class ConfigCommand extends SfdxCommand {
 
     this.responses.forEach((response) => {
       if (response.error) {
-        throw response.error;
+        process.exitCode = 1;
       }
     });
   }
@@ -79,7 +79,7 @@ export abstract class ConfigCommand extends SfdxCommand {
         .filter((response) => !response.success)
         .map((failure) => ({
           name: failure.name,
-          message: failure.error.message,
+          message: failure.error.message.replace(/\.\.$/, '.'),
         })),
     };
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -53,7 +53,9 @@ export abstract class ConfigCommand extends SfdxCommand {
 
     this.responses.forEach((response) => {
       if (response.error) {
-        process.exitCode = 1;
+        // TODO I think throwing here is weird. I think instead, we should set the exitCode to 1
+        // but this breaks unit tests and should be discussed with the team.
+        throw response.error;
       }
     });
   }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -25,5 +25,6 @@ module.exports = {
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
+    '@typescript-eslint/restrict-template-expressions': 'off',
   },
 };

--- a/test/commands/config/get.nut.ts
+++ b/test/commands/config/get.nut.ts
@@ -20,7 +20,6 @@ describe('config:get NUTs', async () => {
       expect(res.stack).to.include('NoConfigKeysFound');
       expect(res.name).to.include('NoConfigKeysFound');
       expect(res.exitCode).to.equal(1);
-      expect(res.commandName).to.include('Get');
     });
 
     it('attempt to config get without keys stdout', () => {
@@ -37,7 +36,7 @@ describe('config:get NUTs', async () => {
     it('gets singular config correctly', () => {
       const res = execCmd('config:get apiVersion --json', { ensureExitCode: 0 });
       // the path variable will change machine to machine, ensure it has the config file and then delete it
-      expect(res.jsonOutput.result[0].path).to.include('sfdx-config.json');
+      expect(res.jsonOutput.result[0].path).to.include('config.json');
       expect(res.jsonOutput.result[0].key).to.include('apiVersion');
       expect(res.jsonOutput.result[0].location).to.include('Global');
       expect(res.jsonOutput.result[0].value).to.include('51.0');
@@ -49,7 +48,7 @@ describe('config:get NUTs', async () => {
       execCmd('config:set apiVersion=52.0');
       const res = execCmd('config:get apiVersion --json', { ensureExitCode: 0 });
       // the path variable will change machine to machine, ensure it has the config file and then delete it
-      expect(res.jsonOutput.result[0].path).to.include('sfdx-config.json');
+      expect(res.jsonOutput.result[0].path).to.include('config.json');
       delete res.jsonOutput.result[0].path;
       expect(res.jsonOutput).to.deep.equal({
         result: [
@@ -83,7 +82,7 @@ describe('config:get NUTs', async () => {
       execCmd('config:set apiVersion=51.0');
       const res = execCmd('config:get apiVersion maxQueryLimit restDeploy --json', { ensureExitCode: 0 });
       Object.values(res.jsonOutput.result).forEach((result) => {
-        expect(result.path).to.include('sfdx-config.json');
+        expect(result.path).to.include('config.json');
         delete result.path;
       });
 

--- a/test/commands/config/get.test.ts
+++ b/test/commands/config/get.test.ts
@@ -7,9 +7,11 @@
 
 import * as path from 'path';
 import { $$, expect, test } from '@salesforce/command/lib/test';
-import { ConfigAggregator, Config } from '@salesforce/core';
+import { ConfigAggregator, SfdxPropertyKeys } from '@salesforce/core';
 import { stubMethod } from '@salesforce/ts-sinon';
 import { IPlugin } from '@oclif/config';
+
+const Config = SfdxPropertyKeys;
 
 describe('config:get', () => {
   async function prepareStubs(global = true) {
@@ -86,7 +88,7 @@ describe('config:get', () => {
         const response = JSON.parse(ctx.stdout);
         expect(response.exitCode).to.equal(1);
         expect(response.status).to.equal(1);
-        expect(response.message).to.equal('Unknown config key: customKey');
+        expect(response.message).to.equal('Unknown config name: customKey.');
       });
 
     test

--- a/test/commands/config/list.test.ts
+++ b/test/commands/config/list.test.ts
@@ -6,8 +6,10 @@
  */
 
 import { $$, expect, test } from '@salesforce/command/lib/test';
-import { ConfigAggregator, Config } from '@salesforce/core';
+import { ConfigAggregator, SfdxPropertyKeys } from '@salesforce/core';
 import { stubMethod } from '@salesforce/ts-sinon';
+
+const Config = SfdxPropertyKeys;
 
 describe('config:list', () => {
   test

--- a/test/commands/config/set.nut.ts
+++ b/test/commands/config/set.nut.ts
@@ -75,7 +75,7 @@ describe('config:set NUTs', async () => {
         failures: [
           {
             name: 'randomKey',
-            message: 'Unknown config name "randomKey"',
+            message: 'Unknown config name: randomKey.',
           },
         ],
       });
@@ -93,7 +93,7 @@ describe('config:set NUTs', async () => {
         verifyValidationError(
           'apiVersion',
           '50',
-          'Invalid config value. Specify a valid Salesforce API version, for example, 42.0'
+          'Invalid config value: Specify a valid Salesforce API version, for example, 42.0.'
         );
       });
     });
@@ -108,7 +108,7 @@ describe('config:set NUTs', async () => {
         verifyValidationError(
           'maxQueryLimit',
           '-2',
-          'Invalid config value. Specify a valid positive integer, for example, 150000'
+          'Invalid config value: Specify a valid positive integer, for example, 150000.'
         );
       });
     });
@@ -126,20 +126,20 @@ describe('config:set NUTs', async () => {
         verifyValidationError(
           'instanceUrl',
           'abc.com',
-          'Invalid config value. Specify a valid Salesforce instance URL'
+          'Invalid config value: Specify a valid Salesforce instance URL.'
         );
       });
     });
 
     describe('defaultdevhubusername', () => {
       it('will fail to validate defaultdevhubusername', () => {
-        verifyValidationError('defaultdevhubusername', 'ab', 'No AuthInfo found for name ab');
+        verifyValidationError('defaultdevhubusername', 'ab', 'No AuthInfo found for name ab.');
       });
     });
 
     describe('defaultusername', () => {
       it('will fail to validate defaultusername', () => {
-        verifyValidationError('defaultusername', 'ab', 'No AuthInfo found for name ab');
+        verifyValidationError('defaultusername', 'ab', 'No AuthInfo found for name ab.');
       });
     });
 
@@ -167,7 +167,7 @@ describe('config:set NUTs', async () => {
         verifyValidationError(
           'disableTelemetry',
           'ab',
-          'Invalid config value. The config value can only be set to true or false.'
+          'Invalid config value: The config value can only be set to true or false.'
         );
       });
     });
@@ -184,7 +184,7 @@ describe('config:set NUTs', async () => {
         verifyValidationError(
           'restDeploy',
           'ab',
-          'Invalid config value. The config value can only be set to true or false.'
+          'Invalid config value: The config value can only be set to true or false.'
         );
       });
     });

--- a/test/commands/config/set.test.ts
+++ b/test/commands/config/set.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { $$, expect, test } from '@salesforce/command/lib/test';
-import { Config, Org, AuthInfo } from '@salesforce/core';
+import { Org, SfdxPropertyKeys, Config } from '@salesforce/core';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 import { SinonStub } from 'sinon';
 
@@ -23,10 +23,10 @@ describe('config:set', () => {
   test
     .do(async () => await prepareStubs())
     .stdout()
-    .command(['config:set', `${Config.API_VERSION}=49.0`, '--global', '--json'])
+    .command(['config:set', `${SfdxPropertyKeys.API_VERSION}=49.0`, '--global', '--json'])
     .it('should return values for all configured properties', (ctx) => {
       const result = JSON.parse(ctx.stdout).result;
-      expect(result.successes).to.deep.equal([{ name: Config.API_VERSION, value: '49.0' }]);
+      expect(result.successes).to.deep.equal([{ name: SfdxPropertyKeys.API_VERSION, value: '49.0' }]);
       expect(configStub.set.callCount).to.equal(1);
     });
 
@@ -37,10 +37,10 @@ describe('config:set', () => {
       orgCreateSpy = stubMethod($$.SANDBOX, Org, 'create').callsFake(async () => orgStub);
     })
     .stdout()
-    .command(['config:set', `${Config.DEFAULT_USERNAME}=MyUser`, '--global', '--json'])
+    .command(['config:set', `${SfdxPropertyKeys.DEFAULT_USERNAME}=MyUser`, '--global', '--json'])
     .it('should instantiate an Org when defaultusername is set', (ctx) => {
       const result = JSON.parse(ctx.stdout).result;
-      expect(result.successes).to.deep.equal([{ name: Config.DEFAULT_USERNAME, value: 'MyUser' }]);
+      expect(result.successes).to.deep.equal([{ name: SfdxPropertyKeys.DEFAULT_USERNAME, value: 'MyUser' }]);
       expect(configStub.set.callCount).to.equal(1);
       expect(orgCreateSpy.callCount).to.equal(1);
     });
@@ -52,37 +52,35 @@ describe('config:set', () => {
       orgCreateSpy = stubMethod($$.SANDBOX, Org, 'create').callsFake(async () => orgStub);
     })
     .stdout()
-    .command(['config:set', `${Config.DEFAULT_DEV_HUB_USERNAME}=MyDevhub`, '--global', '--json'])
+    .command(['config:set', `${SfdxPropertyKeys.DEFAULT_DEV_HUB_USERNAME}=MyDevhub`, '--global', '--json'])
     .it('should instantiate an Org when defaultusername is set', (ctx) => {
       const result = JSON.parse(ctx.stdout).result;
-      expect(result.successes).to.deep.equal([{ name: Config.DEFAULT_DEV_HUB_USERNAME, value: 'MyDevhub' }]);
+      expect(result.successes).to.deep.equal([{ name: SfdxPropertyKeys.DEFAULT_DEV_HUB_USERNAME, value: 'MyDevhub' }]);
       expect(configStub.set.callCount).to.equal(1);
       expect(orgCreateSpy.callCount).to.equal(1);
     });
 
   describe('error cases', () => {
     beforeEach(() => {
-      stubMethod($$.SANDBOX, AuthInfo.prototype, 'loadAuthFromConfig').callsFake(async () => {
-        throw new Error('Error thrown from AuthInfo#loadAuthFromConfig');
-      });
+      stubMethod($$.SANDBOX, Org, 'create').rejects(new Error('Error thrown from Org#create'));
     });
 
     test
       .stdout()
-      .command(['config:set', `${Config.DEFAULT_USERNAME}=NonExistentOrg`, '--global', '--json'])
+      .command(['config:set', `${SfdxPropertyKeys.DEFAULT_USERNAME}=NonExistentOrg`, '--global', '--json'])
       .it('should handle failed org create with --json flag', (ctx) => {
         const response = JSON.parse(ctx.stdout);
         expect(response.status).to.equal(1);
         expect(response.result.failures).to.deep.equal([
-          { name: Config.DEFAULT_USERNAME, message: 'Error thrown from AuthInfo#loadAuthFromConfig' },
+          { name: SfdxPropertyKeys.DEFAULT_USERNAME, message: 'Error thrown from Org#create' },
         ]);
       });
 
     test
       .stdout()
-      .command(['config:set', `${Config.DEFAULT_USERNAME}=NonExistentOrg`, '--global'])
+      .command(['config:set', `${SfdxPropertyKeys.DEFAULT_USERNAME}=NonExistentOrg`, '--global'])
       .it('should handle failed org create with no --json flag', (ctx) => {
-        expect(ctx.stdout).to.include(Config.DEFAULT_USERNAME);
+        expect(ctx.stdout).to.include(SfdxPropertyKeys.DEFAULT_USERNAME);
         expect(ctx.stdout).to.include('NonExistentOrg');
         expect(ctx.stdout).to.include('false');
       });

--- a/test/commands/config/unset.nut.ts
+++ b/test/commands/config/unset.nut.ts
@@ -24,7 +24,6 @@ describe('config:unset NUTs', async () => {
         name: 'NoConfigKeysFound',
         message: 'Please provide config name(s) to unset.',
         exitCode: 1,
-        commandName: 'UnSet',
         warnings: [],
       });
     });

--- a/test/commands/config/unset.test.ts
+++ b/test/commands/config/unset.test.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import { $$, expect, test } from '@salesforce/command/lib/test';
-import { Config } from '@salesforce/core';
+import { Config, SfdxPropertyKeys } from '@salesforce/core';
 import { StubbedType, stubInterface, stubMethod } from '@salesforce/ts-sinon';
 
 describe('config:unset', () => {
@@ -28,20 +28,29 @@ describe('config:unset', () => {
   test
     .do(async () => await prepareStubs())
     .stdout()
-    .command(['config:unset', `${Config.API_VERSION}`, '--global', '--json'])
+    .command(['config:unset', `${SfdxPropertyKeys.API_VERSION}`, '--global', '--json'])
     .it('should unset values for a single property', (ctx) => {
       const result = JSON.parse(ctx.stdout).result;
-      expect(result.successes).to.deep.equal([{ name: Config.API_VERSION }]);
+      expect(result.successes).to.deep.equal([{ name: SfdxPropertyKeys.API_VERSION }]);
       expect(configStub.unset.callCount).to.equal(1);
     });
 
   test
     .do(async () => await prepareStubs())
     .stdout()
-    .command(['config:unset', `${Config.API_VERSION}`, `${Config.DEFAULT_DEV_HUB_USERNAME}`, '--global', '--json'])
+    .command([
+      'config:unset',
+      `${SfdxPropertyKeys.API_VERSION}`,
+      `${SfdxPropertyKeys.DEFAULT_DEV_HUB_USERNAME}`,
+      '--global',
+      '--json',
+    ])
     .it('should unset values for multiple properties', (ctx) => {
       const result = JSON.parse(ctx.stdout).result;
-      expect(result.successes).to.deep.equal([{ name: Config.API_VERSION }, { name: Config.DEFAULT_DEV_HUB_USERNAME }]);
+      expect(result.successes).to.deep.equal([
+        { name: SfdxPropertyKeys.API_VERSION },
+        { name: SfdxPropertyKeys.DEFAULT_DEV_HUB_USERNAME },
+      ]);
       expect(configStub.unset.callCount).to.equal(2);
     });
 
@@ -58,19 +67,19 @@ describe('config:unset', () => {
   test
     .do(async () => await prepareStubs(true))
     .stdout()
-    .command(['config:unset', `${Config.API_VERSION}`, '--global', '--json'])
+    .command(['config:unset', `${SfdxPropertyKeys.API_VERSION}`, '--global', '--json'])
     .it('should handle errors with --json flag', (ctx) => {
       const response = JSON.parse(ctx.stdout);
       expect(response.status).to.equal(1);
-      expect(response.result.failures).to.deep.equal([{ name: Config.API_VERSION, message: 'Unset Error!' }]);
+      expect(response.result.failures).to.deep.equal([{ name: SfdxPropertyKeys.API_VERSION, message: 'Unset Error!' }]);
     });
 
   test
     .do(async () => await prepareStubs(true))
     .stdout()
-    .command(['config:unset', `${Config.API_VERSION}`, '--global'])
+    .command(['config:unset', `${SfdxPropertyKeys.API_VERSION}`, '--global'])
     .it('should handle errors with --json flag', (ctx) => {
-      expect(ctx.stdout).to.include(Config.API_VERSION);
+      expect(ctx.stdout).to.include(SfdxPropertyKeys.API_VERSION);
       expect(ctx.stdout).to.include('false');
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@salesforce/dev-config/tsconfig",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "lib"
+    "outDir": "lib",
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,7 +5652,7 @@ typescript@^4.1.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
-typescript@~4.3.2:
+typescript@^4.3.5, typescript@~4.3.2:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -580,13 +580,34 @@
     chalk "^2.4.2"
     cli-ux "^4.9.3"
 
-"@salesforce/core@^2.15.2", "@salesforce/core@^2.2.0", "@salesforce/core@^2.20.3", "@salesforce/core@^2.23.4":
+"@salesforce/core@^2.2.0", "@salesforce/core@^2.20.3", "@salesforce/core@^2.23.4":
   version "2.25.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-2.25.1.tgz#2be78b4fc824bfb69537174a0440ba35d19d8fa4"
   integrity sha512-kRo1Uce8sFFXNBEu3odJ4zsFkvja+s/cmj7ICI6EvCsgwMHSLCw4P7zhqAsOJnBUim3M2qb4p0HpVtkQ4Cz3Kg==
   dependencies:
     "@salesforce/bunyan" "^2.0.0"
     "@salesforce/kit" "^1.5.0"
+    "@salesforce/schemas" "^1.0.1"
+    "@salesforce/ts-types" "^1.5.13"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/jsforce" "^1.9.29"
+    "@types/mkdirp" "^1.0.1"
+    debug "^3.1.0"
+    graceful-fs "^4.2.4"
+    jsen "0.6.6"
+    jsforce "^1.10.1"
+    jsonwebtoken "8.5.0"
+    mkdirp "1.0.4"
+    sfdx-faye "^1.0.9"
+    ts-retry-promise "^0.6.0"
+
+"@salesforce/core@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.3.1.tgz#0e7ea5742fcbc167542d503bbd618d00142ce016"
+  integrity sha512-UCQ2VYJQthDazGGCaWgQpvpMcgGwaf0NC5d7SL2Qx/Lz9d/C/U7U0OeRBtBrjePodZp/HpEeTnrbGjut+3DaOw==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.5.8"
     "@salesforce/schemas" "^1.0.1"
     "@salesforce/ts-types" "^1.5.13"
     "@types/graceful-fs" "^4.1.5"
@@ -655,6 +676,14 @@
     "@salesforce/ts-types" "^1.5.5"
     tslib "^1.10.0"
 
+"@salesforce/kit@^1.5.8":
+  version "1.5.17"
+  resolved "https://registry.yarnpkg.com/@salesforce/kit/-/kit-1.5.17.tgz#4fd9c50ba2e072c50d319654f86f86808c544795"
+  integrity sha512-Uuh+v7WPSo+L21moVprl+jbDTl3ndmcJM5et/vFLZW4ur6CCJCJSoReM9ttF1qZuQskyCyhVZo6/aMZrVUe+rQ==
+  dependencies:
+    "@salesforce/ts-types" "^1.5.20"
+    tslib "^2.2.0"
+
 "@salesforce/plugin-command-reference@^1.3.0":
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/@salesforce/plugin-command-reference/-/plugin-command-reference-1.3.4.tgz#a67358868c512784542cdc7cd802778150322103"
@@ -692,6 +721,13 @@
   version "1.5.17"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.5.17.tgz#d69e92dfa716638d84b244a2611be80fb7986024"
   integrity sha512-zyF1+4EacGsIWtfntbq7PvxjB2XABz33RzKfOhot15JC4tFiQaSFPtNb8d6hj7BkQSjo2Zs3qEeLJwRFcpaEIQ==
+  dependencies:
+    tslib "^2.2.0"
+
+"@salesforce/ts-types@^1.5.20":
+  version "1.5.20"
+  resolved "https://registry.yarnpkg.com/@salesforce/ts-types/-/ts-types-1.5.20.tgz#f6875a710ceca48223b240026a14af6d3b39882f"
+  integrity sha512-Ov6um4CWd63EvkRavkHG0J/P9XYL55sdkDWPMr7+AIgqh5flHxDRz09/C4e9M94aX30rzJxW4TVX6EBf4Cu2BQ==
   dependencies:
     tslib "^2.2.0"
 


### PR DESCRIPTION
### What does this PR do?
Updates config to use `@salesforce/core@v3` to support sf. This will allow new config keys and support interoperability. Requires https://github.com/forcedotcom/sfdx-core/pull/433

Doing a major version bump on a `sf` tag since this version should only be used with `sf`. When this becomes latest, we will have to remove `@salesforce/plugin-config` as a pinned dep in `sfdx`.  

### What issues does this PR fix or reference?
@W-9546117@