### PR TITLE
fix: move Config modification to init hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "bugs": "https://github.com/forcedotcom/cli",
   "dependencies": {
     "@oclif/core": "^1.5.3",
+    "@oclif/test": "^2.1.0",
     "@salesforce/command": "^5.0.4",
     "@salesforce/core": "^3.12.1",
     "tslib": "^2"
   },
   "devDependencies": {
-    "oclif": "^2.6.1",
     "@oclif/plugin-command-snapshot": "^3",
     "@oclif/plugin-help": "^3.0.1",
     "@salesforce/cli-plugins-testkit": "^1.3.0",
@@ -37,6 +37,7 @@
     "lint-staged": "^11.0.0",
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
+    "oclif": "^2.6.1",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.0",
     "shx": "0.3.4",

--- a/src/commands/config/list.ts
+++ b/src/commands/config/list.ts
@@ -5,25 +5,18 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {
-  Config,
+  // Config,
   ConfigAggregator,
   ConfigInfo,
   Messages,
-  SFDX_ALLOWED_PROPERTIES,
+  // SFDX_ALLOWED_PROPERTIES,
   SfdxPropertyKeys,
 } from '@salesforce/core';
 import { ConfigCommand } from '../../config';
 
 Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-config', 'list');
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-Config.allowedProperties = [
-  ...SFDX_ALLOWED_PROPERTIES.map((entry) => {
-    entry.deprecated = false;
-    return entry;
-  }),
-];
+
 export default class List extends ConfigCommand {
   public static readonly description = messages.getMessage('description');
   public static aliases = ['force:config:list'];

--- a/src/commands/config/list.ts
+++ b/src/commands/config/list.ts
@@ -4,14 +4,7 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {
-  // Config,
-  ConfigAggregator,
-  ConfigInfo,
-  Messages,
-  // SFDX_ALLOWED_PROPERTIES,
-  SfdxPropertyKeys,
-} from '@salesforce/core';
+import { ConfigAggregator, ConfigInfo, Messages, SfdxPropertyKeys } from '@salesforce/core';
 import { ConfigCommand } from '../../config';
 
 Messages.importMessagesDirectory(__dirname);

--- a/src/hooks/init/load_config_meta.ts
+++ b/src/hooks/init/load_config_meta.ts
@@ -48,6 +48,15 @@ function loadConfigMeta(plugin: Interfaces.Plugin): ConfigPropertyMeta | undefin
 }
 
 const hook: Hook<'init'> = ({ config }): Promise<void> => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  Config.allowedProperties = [
+    ...SFDX_ALLOWED_PROPERTIES.map((entry) => {
+      entry.deprecated = false;
+      return entry;
+    }),
+  ];
+
   const flattenedConfigMetas = (config.plugins || [])
     .map((plugin) => {
       const configMeta = loadConfigMeta(plugin);
@@ -63,15 +72,6 @@ const hook: Hook<'init'> = ({ config }): Promise<void> => {
   if (flattenedConfigMetas.length) {
     Config.addAllowedProperties(flattenedConfigMetas);
   }
-
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  Config.allowedProperties = [
-    ...SFDX_ALLOWED_PROPERTIES.map((entry) => {
-      entry.deprecated = false;
-      return entry;
-    }),
-  ];
 
   return;
 };

--- a/src/hooks/init/load_config_meta.ts
+++ b/src/hooks/init/load_config_meta.ts
@@ -5,16 +5,15 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { Hook, IPlugin } from '@oclif/config';
-import { tsPath } from '@oclif/config/lib/ts-node';
-import { ConfigPropertyMeta, Logger } from '@salesforce/core';
-import { Config } from '@salesforce/core';
+import type { Hook, Interfaces } from '@oclif/core';
+import { tsPath } from '@oclif/core';
+import { Config, ConfigPropertyMeta, Logger, SFDX_ALLOWED_PROPERTIES } from '@salesforce/core';
 import { isObject, get } from '@salesforce/ts-types';
 
 const log = Logger.childFromRoot('plugin-config:load_config_meta');
 const OCLIF_META_PJSON_KEY = 'configMeta';
 
-function loadConfigMeta(plugin: IPlugin): ConfigPropertyMeta | undefined {
+function loadConfigMeta(plugin: Interfaces.Plugin): ConfigPropertyMeta | undefined {
   let configMetaRequireLocation: string | undefined;
 
   try {
@@ -39,6 +38,7 @@ function loadConfigMeta(plugin: IPlugin): ConfigPropertyMeta | undefined {
   try {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
     const configMetaPathModule = require(configMetaRequireLocation);
+
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     return configMetaPathModule?.default ?? configMetaPathModule;
   } catch {
@@ -47,8 +47,8 @@ function loadConfigMeta(plugin: IPlugin): ConfigPropertyMeta | undefined {
   }
 }
 
-const hook: Hook<'init'> = ({ config: oclifConfig }) => {
-  const flattenedConfigMetas = (oclifConfig.plugins || [])
+const hook: Hook<'init'> = ({ config }): Promise<void> => {
+  const flattenedConfigMetas = (config.plugins || [])
     .map((plugin) => {
       const configMeta = loadConfigMeta(plugin);
       if (!configMeta) {
@@ -63,6 +63,17 @@ const hook: Hook<'init'> = ({ config: oclifConfig }) => {
   if (flattenedConfigMetas.length) {
     Config.addAllowedProperties(flattenedConfigMetas);
   }
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  Config.allowedProperties = [
+    ...SFDX_ALLOWED_PROPERTIES.map((entry) => {
+      entry.deprecated = false;
+      return entry;
+    }),
+  ];
+
+  return;
 };
 
 export default hook;

--- a/test/hooks/load_config_meta.test.ts
+++ b/test/hooks/load_config_meta.test.ts
@@ -6,19 +6,27 @@
  */
 
 import * as path from 'path';
-import { $$, expect, test } from '@salesforce/command/lib/test';
+import { test, expect } from '@oclif/test';
+import { Plugin } from '@oclif/core';
 import { Config } from '@salesforce/core';
 import { stubMethod } from '@salesforce/ts-sinon';
-import { SinonStub } from 'sinon';
-import { Plugin } from '@oclif/core';
+import * as sinon from 'sinon';
+import { SinonSandbox, SinonStub } from 'sinon';
 import tsSrcConfigMetaMock from '../config-meta-mocks/typescript-src/src/config-meta';
 import jsLibConfigMetaMock from '../config-meta-mocks/javascript-lib/lib/config-meta';
 
+process.env.NODE_ENV = 'development';
+
 describe('hooks', () => {
+  let sandbox: SinonSandbox;
   beforeEach(() => {
-    stubMethod($$.SANDBOX, Config, 'addAllowedProperties');
+    sandbox = sinon.createSandbox();
+    stubMethod(sandbox, Config, 'addAllowedProperties');
   });
 
+  afterEach(() => {
+    sandbox.restore();
+  });
   test
     .stdout()
     .loadConfig()

--- a/yarn.lock
+++ b/yarn.lock
@@ -887,7 +887,7 @@
 
 "@oclif/test@^2.1.0":
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@oclif/test/-/test-2.1.0.tgz#e5a0ba619c890770782e48c82d18f5921e2d2b9f"
+  resolved "https://registry.npmjs.org/@oclif/test/-/test-2.1.0.tgz#e5a0ba619c890770782e48c82d18f5921e2d2b9f"
   integrity sha512-o+JTv3k28aMUxywJUlJY1/DORLqumoZFRII492phOmtXM16rD6Luy3z1qinT4BvEtPj2BzOPd2whr/VdYszaYw==
   dependencies:
     "@oclif/core" "^1.3.1"


### PR DESCRIPTION
### What does this PR do?

Moves the monkey patching of `Config.allowedProperties` to the `init` hook so that it works for all config commands

### What issues does this PR fix or reference?

https://github.com/forcedotcom/cli/issues/1480
@W-10996313@