### PR TITLE
fix: bump core for logfile rotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
   "dependencies": {
     "@oclif/core": "^1.5.3",
     "@salesforce/command": "^5.0.4",
-    "@salesforce/core": "^3.12.1",
+    "@salesforce/core": "^3.13.1",
     "tslib": "^2"
   },
   "devDependencies": {
-    "oclif": "^2.6.1",
     "@oclif/plugin-command-snapshot": "^3",
     "@oclif/plugin-help": "^3.0.1",
     "@salesforce/cli-plugins-testkit": "^1.3.0",
@@ -37,6 +36,7 @@
     "lint-staged": "^11.0.0",
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
+    "oclif": "^2.6.1",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.0",
     "shx": "0.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,7 +1073,32 @@
     semver "^7.3.5"
     ts-retry-promise "^0.6.0"
 
-"@salesforce/core@^3.12.1", "@salesforce/core@^3.7.9":
+"@salesforce/core@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.13.1.tgz#0a4e5844f3d4ae1c559fe0dab5e449e564239ce0"
+  integrity sha512-UBLBkJBxHv4PoU4Ke6NTyk/pEPxqs2u0h9Pkwhwns0Ao6MWENWKobj5qZfVItoBXWADWEbRxa/ahb0X/9y07Cw==
+  dependencies:
+    "@salesforce/bunyan" "^2.0.0"
+    "@salesforce/kit" "^1.5.34"
+    "@salesforce/schemas" "^1.1.0"
+    "@salesforce/ts-types" "^1.5.20"
+    "@types/graceful-fs" "^4.1.5"
+    "@types/mkdirp" "^1.0.2"
+    "@types/semver" "^7.3.9"
+    archiver "^5.3.0"
+    change-case "^4.1.2"
+    debug "^3.2.7"
+    faye "^1.4.0"
+    form-data "^4.0.0"
+    graceful-fs "^4.2.9"
+    js2xmlparser "^4.0.1"
+    jsen "0.6.6"
+    jsforce "2.0.0-beta.7"
+    jsonwebtoken "8.5.1"
+    mkdirp "1.0.4"
+    ts-retry-promise "^0.6.0"
+
+"@salesforce/core@^3.7.9":
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/@salesforce/core/-/core-3.12.1.tgz#6ef20a58777a5368a5804817f11046737fa90baf"
   integrity sha512-j7WvlPwhTLBMBdnF/6Og3oqcM72tGqK99UHK/UqJpGaX0HcadnxMyL3uOMi8aAautvg4BnpfGjesn0pinqKVXw==


### PR DESCRIPTION
### What does this PR do?
dependency bump to verify new core
if nothing else requires it, will force sfdx-cli to the minimum specified here

### What issues does this PR fix or reference?
